### PR TITLE
Add `ipython` to `requirements.txt` align with `ReadMe` instructions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scikit-image==0.18.3
 scipy>=1.4
 typing_extensions==3.10.0.2
 vispy==0.6.6
+ipython


### PR DESCRIPTION
Your usage instructions recommend using `ipython` but the conda environment that is generated from the installation instructions does not include it. 