### PR TITLE
Fix various errors when loading images/h5 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.vscode
+.eggs
+.pytest_cache
+__pycache__
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -58,11 +58,67 @@ in red)
 
 To draw masks, simply add a `Shapes layer` and start drawing polygons over the images. Note, these would not currently be used within DeepLabCut, but could be useful for other applications.
 
-**Save:**
+### Save Layers
 
 Annotations and segmentations are saved with `File > Save Selected Layer(s)...`
 (or its shortcut `Ctrl+S`). For convenience, the save file dialog opens automatically into the folder containing your images or your h5 data file. 
 - As a reminder, DLC will only use the H5 file; so be sure if you open already labeled images you save/overwrite the H5. If you label from scratch, you should save the file as `CollectedData_YourName.h5`
 - Note that when saving segmentation masks, data will be stored into
 a folder bearing the name provided in the dialog window.
-- Note,  before selecting `save layer` as as (or `ctrl-S`) make sure the key points layer is selected. If the user clicked on the image(s) layer first, does save as, then closes the window, any labeling work during that session will be lost!
+- Note,  before selecting `save layer` as as (or `Ctrl+S`) make sure the key points layer is selected. If the user clicked on the image(s) layer first, does save as, then closes the window, any labeling work during that session will be lost!
+
+## Workflow
+
+Suggested workflows, depending on the image folder contents:
+
+1. **Labelling from scratch** – the image folder does not contain `CollectedData_<ScorerName>.h5` file.
+
+    Open *napari* as described in [Open GUI & Usage](#open-gui--usage) and open an image folder together with the DeepLabCut project's `config.yaml`.
+    The image folder creates an *image layer* with the images to label.
+    Supported image formats are: `jpg`, `jpeg`, `png`.
+    The `config.yaml` file creates a *keypoints layer*, which holds metadata (such as keypoints read from the config file) necessary for labelling.
+    Select the *keypoints layer* in the layer list (lower left pane on the GUI) and click on the *+*-symbol in the layer controls menu (upper left pane) to start labelling.
+    The current keypoint can be viewed/selected in the keypoints menu (bottom pane).
+    The slider below the displayed image (right pane) allows selecting the image to label.
+
+    To save the labelling progress refer to [Save Layers](#save-layers).
+    If the console window does not display any errors, the image folder should now contain a `CollectedData_<ScorerName>.h5` file.
+    (Note: For convenience, a CSV file with the same name is also saved.)
+
+1. **Resuming labelling** – the image folder contains a `CollectedData_<ScorerName>.h5` file.
+
+    Open *napari* and open an image folder (which needs to contain a `CollectedData_<ScorerName>.h5` file).
+    In this case, it is not necessary to open the DLC project's `config.yaml` file, as all necessary metadata is read from the `h5` data file.
+
+    Saving works as described in *1*.
+
+1. **Refining labels** – the image folder contains a `machinelabels-iter<#>.h5` file.
+
+    The process is analog to *2*.
+
+### Labelling multiple image folders
+
+Labelling multiple image folders has to be done in sequence, i.e., only one image folder can be opened at a time.
+After labelling the images of a particular folder is done and the associated *keypoints layer* has been saved, *all* layers should be removed from the layers list (lower left pane on the GUI) by selecting them and clicking on the trashcan icon.
+Now, another image folder can be labelled, following the process described in *1*, *2*, or *3*, depending on the particular image folder.
+
+## Known Issues
+
+### Cannot load image folder with single image file
+
+The `pims` module fails to read images from a folder with only a single image.
+
+The following error will be raised:
+
+```python
+ValueError: No plugin found capable of reading 'E:\\DLC-Project\\labeled-data\\label-from-scratch\\*.png'.
+```
+
+### Empty `CollectedData` file
+
+If an image folder with an empty `CollectedData_<ScorerName>.h5` file gets opened, i.e.,
+the file does not contain any annotation data, then the following error gets raised:
+
+```python
+ValueError: No plugin found capable of reading '/home/DLC-Project/labeled-data/image-folder/*.h5'.
+```

--- a/dlclabel/layers.py
+++ b/dlclabel/layers.py
@@ -1,11 +1,13 @@
-import numpy as np
 from collections import namedtuple
-from dlclabel.misc import CycleEnum
 from enum import auto
+from typing import List, Sequence, Union
+
+import numpy as np
 from napari.layers import Points
 from napari.utils.events import Event
 from napari.utils.status_messages import format_float
-from typing import List, Sequence, Union
+
+from dlclabel.misc import CycleEnum
 
 
 class LabelMode(CycleEnum):

--- a/dlclabel/misc.py
+++ b/dlclabel/misc.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
-import numpy as np
-import pandas as pd
+
 from enum import Enum, EnumMeta
 from itertools import cycle
-from napari.utils import colormaps
+import os
 from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import pandas as pd
+from napari.utils import colormaps
 
 
 def unsorted_unique(array: Sequence) -> np.ndarray:
@@ -128,3 +131,25 @@ class CycleEnum(Enum, metaclass=CycleEnumMeta):
 
     def __str__(self):
         return self.value
+
+
+def to_os_dir_sep(path: str) -> str:
+    """
+    Replace all directory separators in `path` with `os.path.sep`.
+
+    Raises
+    ------
+    ValueError: if `path` contains both UNIX and Windows directory separators.
+
+    """
+    win_sep, unix_sep = '\\', '/'
+
+    # On UNIX systems, `win_sep` is a valid character in directory and file
+    # names. This function fails if both are present.
+    if win_sep in path and unix_sep in path:
+        raise ValueError(
+            f'"{path}" may not contain both "{win_sep}" and "{unix_sep}"!')
+
+    sep = win_sep if win_sep in path else unix_sep
+
+    return os.path.sep.join(path.split(sep))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(filename) as f:
 
 setup(
     name="napari-DeepLabCut",
-    version="0.0.1",
+    version="0.0.2",
     maintainer="Jessy Lauer",
     packages=find_packages(),
     include_package_data=True,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from dlclabel import misc
 
@@ -47,3 +48,15 @@ def test_cycle_enum():
     assert next(cycle_enum) is cycle_enum.ITEM2
     assert next(cycle_enum) is cycle_enum.ITEM3
     assert next(cycle_enum) is cycle_enum.ITEM1
+
+
+def test_to_os_dir_sep():
+    path = r'labeled-data\img folder1'
+    expected = 'labeled-data/img folder1' \
+        if os.path.sep == '/' else path
+    assert misc.to_os_dir_sep(path) == expected
+
+    path = r'labeled-data/img folder1'
+    expected = r'labeled-data\img folder1' \
+        if os.path.sep == '\\' else path
+    assert misc.to_os_dir_sep(path) == expected


### PR DESCRIPTION
Fixes DeepLabCut/napari-DeepLabCut#12

- Fix cases where metadata['root'] is not set: make root always point to
  DLC project root directory
- Fix error in `_remap_frame_indices()` when detection of missing
  frames fails due to different directory separators in h5 data file
  and OS running napari
- Set name of image layer to name of image folder
- Fix "out of bounds" error when metadata['properties']['id'] is an
  empty array
- Fix "missing column" error when dataframe (annotation data) is
  missing the "likelihood" column
- Also store CollectedData h5 file as CSV for easier inspection of
  the data written
- Fix warning (printed to console) when writing annotation data
  (use keyword argument w/ MultiIndex.set_names)
- Add "Workflow" and "Known Issues" section to README